### PR TITLE
reserve capacity on BytesMut before calling put

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: rust
+rust:
+    - stable
+    - beta
+    - nightly
+matrix:
+    allow_failures:
+        - rust: nightly
+script:
+    - cargo build
+    - cargo test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nsq-rs
 
+[![Build Status](https://travis-ci.org/gsquire/nsq-rs.svg?branch=master)](https://travis-ci.org/gsquire/nsq-rs)
+
 An unoffical NSQ client for Rust.
 
 Work in Progress.

--- a/src/message.rs
+++ b/src/message.rs
@@ -64,8 +64,12 @@ impl Encoder for NsqResponder {
 
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         match item {
-            MessageReply::Nop => dst.put("NOP\n"),
+            MessageReply::Nop => {
+                dst.reserve(4);
+		dst.put("NOP\n");
+            }
             MessageReply::Fin(id) => {
+                dst.reserve(21);
                 dst.put("FIN ");
                 dst.put(id);
                 dst.put("\n");

--- a/src/message.rs
+++ b/src/message.rs
@@ -65,11 +65,15 @@ impl Encoder for NsqResponder {
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         match item {
             MessageReply::Nop => {
-                dst.reserve(4);
-		dst.put("NOP\n");
+                if dst.remaining_mut() < 4{
+                    dst.reserve(4);
+                }
+                dst.put("NOP\n");
             }
             MessageReply::Fin(id) => {
-                dst.reserve(21);
+                if dst.remaining_mut() < 21{
+                    dst.reserve(21);
+                }
                 dst.put("FIN ");
                 dst.put(id);
                 dst.put("\n");


### PR DESCRIPTION
BufMut::put doesn't extend the buffer when it's full, which leads to the buffer growing out of capacity. This leads to `assertion failed: self.remaining_mut() >= src.remaining()`